### PR TITLE
Add support for CSI BAM index files (REVIEW)

### DIFF
--- a/index.php
+++ b/index.php
@@ -569,16 +569,16 @@
 						</div>
 					<!-- Bam input -->
 						<div id="bam" class="tab-pane fade">
-							<p>Select bam and corresponding bam.bai</p>
+							<p>Select bam and corresponding index (bai/csi)</p>
 							<input type="file" name="files[]" id="bam_file"	multiple />
 							<span id="bam_info_icon" ><span class="glyphicon glyphicon-info-sign"></span> Instructions</span>
 						</div>
 						<div id="url_bam" class="tab-pane fade">
 							<input type="text" id="bam_url_input" value="http://">
 							<input type="submit" id="submit_bam_url" value="Load bam file from a url">
-							<p>Make sure the bam file exists and that it has a corresponding .bai file with an identical filename except for the addition of the .bai suffix. If the bam file does not exist or cannot be read, a header will fail to appear but there will be no error message. If the header of the bam file does not show up within about 10 seconds, loading the bam file has probably failed and you should check to make sure it actually exists at the given address. (To test for this, put the url into your web browser. If it starts downloading the bam file, then also check whether adding .bai to the url downloads the index file. If one of these does not start a download, then the file does not exist.)
+							<p>Make sure the bam file exists and that it has a corresponding index (.bai or .csi) file with an identical filename except for the addition of the .bai or .csi suffix. If the bam file does not exist or cannot be read, a header will fail to appear but there will be no error message. If the header of the bam file does not show up within about 10 seconds, loading the bam file has probably failed and you should check to make sure it actually exists at the given address. (To test for this, put the url into your web browser. If it starts downloading the bam file, then also check whether adding .bai or .csi to the url downloads the index file. If one of these does not start a download, then the file does not exist.)
 							</p>
-							<p>Note that the bam file does not get read into memory, but the .bai file does, so if the .bai file is huge, it will take a while the first time you fetch reads from the bam file. 
+							<p>Note that the bam file does not get read into memory, but the index file does, so if the index file is huge, it will take a while the first time you fetch reads from the bam file. 
 							</p>
 						</div>
 					<!-- Coords input -->

--- a/js/bam/bam.iobio.js
+++ b/js/bam/bam.iobio.js
@@ -10,11 +10,11 @@ var Bam = Class.extend({
       if (typeof(this.bamUri) == "object") {
          this.sourceType = "file";
          this.bamBlob = new BlobFetchable(bamUri);
-         this.baiBlob = new BlobFetchable(this.options.bai); // *** add if statement if here ***
+         this.indexBlob = new BlobFetchable(this.options.index); // *** add if statement if here ***
          this.promises = [];
          this.bam = undefined;
          var me = this;
-         makeBam(this.bamBlob, this.baiBlob, function(bam) {
+         makeBam(this.bamBlob, this.indexBlob, function(bam) {
             me.setHeader(bam.header);
             me.provide(bam);
          });
@@ -354,7 +354,7 @@ var Bam = Class.extend({
           cmd.run();
 
       } else if (me.sourceType == 'file') {
-          me.baiBlob.fetch(function(header){
+          me.indexBlob.fetch(function(header){
              if (!header) {
                   return dlog("Couldn't access BAI");
               }

--- a/js/bam/bam.js
+++ b/js/bam/bam.js
@@ -83,7 +83,12 @@ function makeBam(data, index, callback) {
             return alert("Couldn't access index file");
         }
 
-	var uncba = new Uint8Array(header);
+	var unc = header;
+	if (/[^.]+$/.exec(bam.index.blob.name)[0] == 'csi') {
+		// csi extensions need decompression
+		unc = unbgzf(header);
+	}
+	var uncba = new Uint8Array(unc);
 	var indexMagic = readInt(uncba, 0);
 	if (indexMagic == BAI_MAGIC) {
 		bam.index_type = 'bai';
@@ -111,11 +116,11 @@ function makeBam(data, index, callback) {
 			//console.log('blockStart=' + blockStart);
 			//console.log('blockLength=' + blockLength);
 			if (nbin > 0) {
-				bam.indices[ref] = new Uint8Array(header, blockStart, blockLength);
+				bam.indices[ref] = new Uint8Array(unc, blockStart, blockLength);
 			}
 		}
 	} else if(indexMagic == CSI_MAGIC) {
-		bam.index_type = csi'';
+		bam.index_type = 'csi';
 		var min_shift = readInt(uncba, 4);
 		var depth = readInt(uncba, 8);
 		//console.log('min_shift=' + min_shift);
@@ -150,7 +155,7 @@ function makeBam(data, index, callback) {
 			//console.log('blockStart=' + blockStart,);
 			//console.log('blockLength=' + blockLength);
 			if (nbin > 0) {
-				bam.indices[ref] = new Uint8Array(header, blockStart, blockLength);
+				bam.indices[ref] = new Uint8Array(unc, blockStart, blockLength);
 			}
 		}
 	} else {

--- a/js/vis.js
+++ b/js/vis.js
@@ -4382,23 +4382,40 @@ function create_bam(files) {
 
 	// From bam.iobio, thanks Marth lab!
 	if (files.length != 2) {
-		 alert('must select both a .bam and .bai file');
+		 alert('must select both a .bam and index (.bai or .csi) file');
 		 return;
 	}
 
 	var fileType0 = /[^.]+$/.exec(files[0].name)[0];
 	var fileType1 = /[^.]+$/.exec(files[1].name)[0];
 
-	if (fileType0 == 'bam' && fileType1 == 'bai') {
-		bamFile = files[0];
-		baiFile = files[1];
-	 } else if (fileType1 == 'bam' && fileType0 == 'bai') {
+	switch(fileType0) {
+		case "bam":
+			bamFile = files[0];
+			break;
+		case "bai":
+			indexFile = files[0];
+			break;
+		case "csi":
+			indexFile = files[0];
+			break;
+	}
+	switch(fileType1) {
+		case "bam":
 			bamFile = files[1];
-			baiFile = files[0];
-	 } else {
-			alert('must select both a .bam and .bai file');
-	 }
-	_Bam = new Bam( bamFile, { bai: baiFile });
+			break;
+		case "bai":
+			indexFile = files[1];
+			break;
+		case "csi":
+			indexFile = files[1];
+			break;
+	}
+	if (typeof bamFile == 'undefined' || typeof indexFile == 'undefined') {
+		alert('must select both a .bam and index (.bai or .csi) file');
+	}
+
+	_Bam = new Bam( bamFile, { index: indexFile });
 
 	_settings.alignment_info_text = "Bam from file: " + bamFile.name;
 	set_alignment_info_text();
@@ -4409,13 +4426,13 @@ function create_bam(files) {
 
 
 function wait_then_run_when_bam_file_loaded(counter) {
-	if (counter == undefined) {
+	if (typeof counter == 'undefined') {
 		counter = 0;
 	} else if (counter > 30) {
 		user_message("Error","File taking too long to load")
 		return;
 	}
-	if (_Bam.header != undefined) {
+	if (typeof _Bam.header != 'undefined') {
 		console.log("ready");
 		bam_loaded();
 	} else {


### PR DESCRIPTION
Most things are now in place. Although I still need to implement support for the bgzip compressed CSI index. If you want to test with the current code you'll need to:

```bash
samtools index -c my.bam
gunzip -dc my.bam.csi > my.bam.csi.uncompressed
mv my.bam.csi.uncompressed my.bam.csi
```

I'll try to make a further commit to this pull request next week which will add support for the compressed natively compressed `CSI` index.