### PR TITLE
Add preset BAMs including GIAB HG008 tumor data.

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 									<p>Note that the bam file does not get read into memory, but the index file does, so if the index file is huge, it will take a while the first time you fetch reads from the bam file. 
 									</p>
 
-									<h4>Here are some sampple BAMs to play with:</h4>
+									<h4>Here are some sample BAMs to play with:</h4>
 									<div id="bam_presets"></div>
 								</div>
 								<div id="bam" class="tab-pane">

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
 					<h3>Getting started</h3>
 					<p>Ribbon is especially useful for viewing complex alignments, like long-read sequencing around large structural variants,
 						alignments/variants that span more than one chromosome, or assembly/assembly alignments.</p>
-					<p>Start by loading a BAM file and picking a locus</p>
+					<p>Start by loading a BAM file and navigating to a position. You can also load a VCF or BED file with variants or regions of interest.</p>
 
 					<p><strong>Examples:</strong></p>
 					<p>PacBio, Illumina, and genome/assembly examples shown in the Examples tab above.</p>
@@ -155,12 +155,9 @@
 								<div id="url_bam" class="tab-pane active">
 									<input type="text" id="bam_url_input" placeholder="https://" style="width: 100%">
 									<input type="submit" id="submit_bam_url" value="Load bam file from a url">
-									<p>Make sure the bam file exists and that it has a corresponding index (.bai or .csi) file with an identical filename except for the addition of the .bai or .csi suffix. If the bam file does not exist or cannot be read, a header will fail to appear but there will be no error message. If the header of the bam file does not show up within about 10 seconds, loading the bam file has probably failed and you should check to make sure it actually exists at the given address. (To test for this, put the url into your web browser. If it starts downloading the bam file, then also check whether adding .bai or .csi to the url downloads the index file. If one of these does not start a download, then the file does not exist.)
+									<p>Make sure the bam file exists and that it has a corresponding index (.bai or .csi) file with an identical filename except for the addition of the .bai or .csi suffix.
 									</p>
-									<p>Note that the bam file does not get read into memory, but the index file does, so if the index file is huge, it will take a while the first time you fetch reads from the bam file. 
-									</p>
-
-									<h4>Here are some sample BAMs to play with:</h4>
+									<strong>Here are some sample BAMs to play with:</strong>
 									<div id="bam_presets"></div>
 								</div>
 								<div id="bam" class="tab-pane">

--- a/index.html
+++ b/index.html
@@ -150,14 +150,18 @@
 							</ul>
 							
 							<div class="tab-content">
+								
 							<!-- Bam input -->
 								<div id="url_bam" class="tab-pane active">
-									<input type="text" id="bam_url_input" value="http://" style="width: 100%">
+									<input type="text" id="bam_url_input" placeholder="https://" style="width: 100%">
 									<input type="submit" id="submit_bam_url" value="Load bam file from a url">
 									<p>Make sure the bam file exists and that it has a corresponding index (.bai or .csi) file with an identical filename except for the addition of the .bai or .csi suffix. If the bam file does not exist or cannot be read, a header will fail to appear but there will be no error message. If the header of the bam file does not show up within about 10 seconds, loading the bam file has probably failed and you should check to make sure it actually exists at the given address. (To test for this, put the url into your web browser. If it starts downloading the bam file, then also check whether adding .bai or .csi to the url downloads the index file. If one of these does not start a download, then the file does not exist.)
 									</p>
 									<p>Note that the bam file does not get read into memory, but the index file does, so if the index file is huge, it will take a while the first time you fetch reads from the bam file. 
 									</p>
+
+									<h4>Here are some sampple BAMs to play with:</h4>
+									<div id="bam_presets"></div>
 								</div>
 								<div id="bam" class="tab-pane">
 									<p>Select bam and corresponding index (bai/csi)</p>
@@ -1019,6 +1023,7 @@
 <script src="js/d3-superTable.js"></script>
 <!-- Shared utilities-->
 <script src="js/utils.js"></script>
+<!-- file_parsing also sets up Aioli and makes the global _CLI variable -->
 <script src="js/file_parsing.js"></script>
 <!-- SplitThreader's graph algorithms -->
 <script src="js/SplitThreader.js"></script>

--- a/js/file_parsing.js
+++ b/js/file_parsing.js
@@ -94,15 +94,19 @@ class BamFile extends GenomicFile {
     // CLI.cat(). Based on a few tests run on Illumina and PacBio data, using the command
     // "samtools view -o" followed by "cat" is ~2-3X faster than simply using "samtools view".
     console.time("samtools view");
-    await this.CLI.exec(
+    let std_err_samtools = await this.CLI.exec(
       `samtools view${subsampling} -o /tmp/reads.sam ${this.paths[0]} ${region}`
     );
+    if (std_err_samtools.includes("[E::")) {
+      console.error(std_err_samtools);
+    }
+
     const raw = await this.CLI.cat("/tmp/reads.sam");
     console.timeEnd("samtools view");
 
     if (!raw) {
-      user_message_ribbon("Error", "Could not parse the BAM reads.");
-      return;
+      user_message_ribbon("Error", "No reads in the bam file at this location");
+      return [];
     }
 
     return parseBamReads(raw);

--- a/js/file_parsing.js
+++ b/js/file_parsing.js
@@ -1,3 +1,5 @@
+let _CLI = null;
+
 // =============================================================================
 // Classes for managing genomic files
 // =============================================================================
@@ -31,18 +33,21 @@ class BamFile extends GenomicFile {
   format = "bam";
   header = {
     raw: "",
-    sq: []
-  }
+    sq: [],
+  };
 
   async parseHeader() {
     const raw = await this.CLI.exec(`samtools view -H ${this.paths[0]}`);
     if (!raw) {
-      user_message_ribbon("Error", "No header found. Are you sure this is a bam file?");
+      user_message_ribbon(
+        "Error",
+        "No header found. Are you sure this is a bam file?"
+      );
       return;
     }
 
     this.header = {
-      sq: parseBamHeader(raw)
+      sq: parseBamHeader(raw),
     };
     this.ready = true;
     return this.header;
@@ -57,7 +62,9 @@ class BamFile extends GenomicFile {
     // for long-read data!). This is generally much much faster than trying to load the region
     // so for most cases, the additional runtime is negligible.
     console.time("samtools coverage");
-    const coverage = await this.CLI.exec(`samtools coverage ${this.paths[0]} -r ${region} --no-header`);
+    const coverage = await this.CLI.exec(
+      `samtools coverage ${this.paths[0]} -r ${region} --no-header`
+    );
     console.timeEnd("samtools coverage");
 
     // Estimate how much data we're looking at in the selected region, and subsample if
@@ -67,10 +74,18 @@ class BamFile extends GenomicFile {
     const samplingPct = Math.round((1e6 / (+stats[4] * +stats[6])) * 100) / 100;
     if (samplingPct < 1 && _automation_running && !automation_subsample) {
       if (!_automation_running) {
-        samplingPct = prompt(`⚠️ Warning\n\nThis region contains a lot of data and may crash your browser.\n\nEnter the fraction of reads to sample (use the default if you're not sure):`, samplingPct);
+        samplingPct = prompt(
+          `⚠️ Warning\n\nThis region contains a lot of data and may crash your browser.\n\nEnter the fraction of reads to sample (use the default if you're not sure):`,
+          samplingPct
+        );
       }
       subsampling = ` -s ${samplingPct}`;
-      user_message_ribbon("Warning", `Region contains a lot of data; sampling ${Math.round(samplingPct * 100)}% of reads.`);
+      user_message_ribbon(
+        "Warning",
+        `Region contains a lot of data; sampling ${Math.round(
+          samplingPct * 100
+        )}% of reads.`
+      );
     }
 
     // Stream the SAM output to a temporary file on the virtual filesystem inside the WebWorker.
@@ -79,7 +94,9 @@ class BamFile extends GenomicFile {
     // CLI.cat(). Based on a few tests run on Illumina and PacBio data, using the command
     // "samtools view -o" followed by "cat" is ~2-3X faster than simply using "samtools view".
     console.time("samtools view");
-    await this.CLI.exec(`samtools view${subsampling} -o /tmp/reads.sam ${this.paths[0]} ${region}`);
+    await this.CLI.exec(
+      `samtools view${subsampling} -o /tmp/reads.sam ${this.paths[0]} ${region}`
+    );
     const raw = await this.CLI.cat("/tmp/reads.sam");
     console.timeEnd("samtools view");
 
@@ -101,7 +118,7 @@ function parseBamHeader(raw) {
   return raw
     .trim()
     .split("\n")
-    .filter(d => d.startsWith("@SQ"))
+    .filter((d) => d.startsWith("@SQ"))
     .map((d) => {
       const info = d
         .split("\t")
@@ -139,3 +156,21 @@ function parseBamReads(raw) {
       return record;
     });
 }
+
+// ===========================================================================
+// == Biowasm / Aioli
+// ===========================================================================
+
+// Initialize app on page load
+document.addEventListener("DOMContentLoaded", async () => {
+  // Create Aioli (and the WebWorker in which WASM code will run).
+  // Load assets locally instead of using the CDN.
+  const urlPrefix = `${window.location.origin}/wasm`;
+  _CLI = await new Aioli([
+    { tool: "samtools", version: "1.17", urlPrefix },
+    { tool: "bcftools", version: "1.10", urlPrefix },
+  ]);
+
+  // Get samtools version once initialized
+  console.log("Loaded: samtools", await _CLI.exec("samtools --version-only"));
+});

--- a/js/index_ribbon.js
+++ b/js/index_ribbon.js
@@ -6549,14 +6549,20 @@ const _bam_presets = [
   {
     url: "https://42basepairs.com/download/gs/deepvariant/pacbio-case-study-testdata/HG003.pfda_challenge.grch38.phased.bam",
     name: "HG003 PacBio phased",
+    "42basepairs_url":
+      "https://42basepairs.com/browse/gs/deepvariant/pacbio-case-study-testdata?file=HG003.pfda_challenge.grch38.phased.bam",
   },
   {
-    url: "https://42basepairs.com/download/web/giab/data_somatic/HG008/Liss_lab/PacBio_Onso_20240415/HG008-T_Pacbio-onso_136x_GRCh37.bam",
-    name: "HG008 PacBio Tumor",
+    url: "https://42basepairs.com/download/s3/giab/data_somatic/HG008/Liss_lab/PacBio_Revio_20240125/HG008-T_PacBio-HiFi-Revio_20240125_116x_CHM13v2.0.bam",
+    name: "HG008 PacBio Tumor from GIAB",
+    "42basepairs_url":
+      "https://42basepairs.com/browse/s3/giab/data_somatic/HG008/Liss_lab/PacBio_Revio_20240125/HG008-T_PacBio-HiFi-Revio_20240125_116x_CHM13v2.0.bam",
   },
   {
     url: "https://42basepairs.com/download/r2/genomics-data/alignments_HG002.bam",
     name: "HG002 Illumina",
+    "42basepairs_url":
+      "https://42basepairs.com/browse/r2/genomics-data/alignments_HG002.bam",
   },
 ];
 
@@ -6564,12 +6570,20 @@ function make_bam_presets_list() {
   const bamPresetsContainer = document.getElementById("bam_presets");
 
   _bam_presets.forEach((preset) => {
-    const listItem = document.createElement("li");
-    listItem.textContent = preset.name;
-    listItem.style.cursor = "pointer";
-    listItem.addEventListener("click", () => {
+    let listItem = document.createElement("li");
+    let load_link = document.createElement("span");
+    load_link.textContent = preset.name;
+    load_link.style.cursor = "pointer";
+    load_link.title = preset.url; // Show URL on hover
+    load_link.addEventListener("click", () => {
       read_bam_url(preset.url);
     });
+    listItem.appendChild(load_link);
+    let link_to_42basepairs = document.createElement("a");
+    link_to_42basepairs.href = preset["42basepairs_url"];
+    link_to_42basepairs.textContent = " (source on 42bp)";
+    link_to_42basepairs.target = "_blank";
+    listItem.appendChild(link_to_42basepairs);
     bamPresetsContainer.appendChild(listItem);
   });
 }

--- a/js/index_ribbon.js
+++ b/js/index_ribbon.js
@@ -2272,7 +2272,6 @@ function parse_paired_end(record) {
 
 function consolidate_records(records) {
   // Removing duplicates and pairing up records from paired-end reads
-
   _ribbon_settings.paired_end_mode = false;
   for (var i = 0; i < records.length; i++) {
     if ((records[i].flag & 1) == 1) {
@@ -6550,6 +6549,10 @@ const _bam_presets = [
   {
     url: "https://42basepairs.com/download/gs/deepvariant/pacbio-case-study-testdata/HG003.pfda_challenge.grch38.phased.bam",
     name: "HG003 PacBio phased",
+  },
+  {
+    url: "https://42basepairs.com/download/web/giab/data_somatic/HG008/Liss_lab/PacBio_Onso_20240415/HG008-T_Pacbio-onso_136x_GRCh37.bam",
+    name: "HG008 PacBio Tumor",
   },
   {
     url: "https://42basepairs.com/download/r2/genomics-data/alignments_HG002.bam",

--- a/js/index_ribbon.js
+++ b/js/index_ribbon.js
@@ -6438,7 +6438,6 @@ function parse_bam_record(record) {
 }
 
 function use_fetched_data(records) {
-  // records is [undefined]
   show_bam_is_ready();
 
   var parsed_bam_records = [];

--- a/js/index_ribbon.js
+++ b/js/index_ribbon.js
@@ -33,7 +33,6 @@ var _Features_for_ribbon = [];
 var _focal_region; // {chrom,start,end}:  one region that the bam file, variants, or majority of reads from a sam entry point towards, considered the primary region for read alignment
 
 // Reading bam file
-var _CLI = null;
 var _automation_running = false;
 var _Bam = undefined;
 var _Ref_sizes_from_header = {};
@@ -6270,7 +6269,12 @@ function bam_loaded() {
   d3.select("#variant_input_panel").style("display", "block");
   d3.select("#feature_input_panel").style("display", "block");
 
-  user_message_ribbon("Success", "Loaded alignments from " + _Whole_refs.length + " reference sequences (chromosomes). Use any of the panels below to select a position or variant to zoom in on.");
+  user_message_ribbon(
+    "Success",
+    "Loaded alignments from " +
+      _Whole_refs.length +
+      " reference sequences (chromosomes). Navigate to a position by pasting it above or loading some variants/features."
+  );
 
   refresh_visibility();
 }
@@ -6435,6 +6439,7 @@ function parse_bam_record(record) {
 }
 
 function use_fetched_data(records) {
+  // records is [undefined]
   show_bam_is_ready();
 
   var parsed_bam_records = [];
@@ -6540,6 +6545,33 @@ function submit_bam_url() {
   read_bam_url(url);
 }
 d3.select("#submit_bam_url").on("click", submit_bam_url);
+
+const _bam_presets = [
+  {
+    url: "https://42basepairs.com/download/gs/deepvariant/pacbio-case-study-testdata/HG003.pfda_challenge.grch38.phased.bam",
+    name: "HG003 PacBio phased",
+  },
+  {
+    url: "https://42basepairs.com/download/r2/genomics-data/alignments_HG002.bam",
+    name: "HG002 Illumina",
+  },
+];
+
+function make_bam_presets_list() {
+  const bamPresetsContainer = document.getElementById("bam_presets");
+
+  _bam_presets.forEach((preset) => {
+    const listItem = document.createElement("li");
+    listItem.textContent = preset.name;
+    listItem.style.cursor = "pointer";
+    listItem.addEventListener("click", () => {
+      read_bam_url(preset.url);
+    });
+    bamPresetsContainer.appendChild(listItem);
+  });
+}
+
+make_bam_presets_list();
 
 window.addEventListener("beforeunload", function (event) {
   event.preventDefault();
@@ -6774,24 +6806,6 @@ window.onresize = resizeWindow;
 function resizeWindow() {
   resize_ribbon_views();
 }
-
-// ===========================================================================
-// == Biowasm / Aioli
-// ===========================================================================
-
-// Initialize app on page load
-document.addEventListener("DOMContentLoaded", async () => {
-  // Create Aioli (and the WebWorker in which WASM code will run).
-  // Load assets locally instead of using the CDN.
-  const urlPrefix = `${window.location.origin}/wasm`;
-  _CLI = await new Aioli([
-    { tool: "samtools", version: "1.17", urlPrefix },
-    { tool: "bcftools", version: "1.10", urlPrefix },
-  ]);
-
-  // Get samtools version once initialized
-  console.log("Loaded: samtools", await _CLI.exec("samtools --version-only"));
-});
 
 // ===========================================================================
 


### PR DESCRIPTION
1. Add BAM preset list.
2. Fix a bam loading error for when no reads are found when fetching from a locus.
3. Move _CLI variable and initialization to file_parsing.js so both Ribbon and SplitThreader JS scripts can use it regardless of which is loaded first.

