### PR TITLE
Move navbar items into tabs

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -7,7 +7,7 @@ body {
 }
 
 .navbar {
-  font-size: 2vh;
+  font-size: 20px;
 }
 .panel-group {
   margin-bottom: 1vmin;

--- a/css/custom.css
+++ b/css/custom.css
@@ -33,13 +33,11 @@ body {
   float: left;
 }
 
-#info_panel,
 #start_panel,
 #advanced_settings_panel {
   margin-left: 3vmin;
   margin-right: 3vmin;
 }
-#info_panel .panel-body,
 #start_panel .panel-body,
 #advanced_settings_panel .panel-body {
   padding-left: 2vmin;
@@ -147,7 +145,6 @@ text {
   font-weight: 900;
   font-family: "Lato", "Helvetica", sans-serif;
 }
-#info_panel,
 #advanced_settings_panel {
   display: none;
 }

--- a/index.html
+++ b/index.html
@@ -40,18 +40,14 @@
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 				</button>
-
-			<!-- <a class="navbar-brand" href=".">        Ribbon</a> -->
 			</div>
 			<!-- <div class="navbar-collapse collapse"> -->
 			<ul class="nav navbar-nav" id="navbar">
-				<li><a id="go_to_splitthreader_mode">SplitThreader</a></li>
-				<li><a id="go_to_ribbon_mode">Ribbon</a></li>
-				<li><a id="click_getting_started_link">Info</a></li>
-				<li class="dropdown" id="user_data_navbar_item">
+				<li><a href="/">Ribbon</a></li>
+				<li class="dropdown" id="user_data_navbar_item" style="visibility: hidden">
 					<a href="" class="dropdown-toggle" data-toggle="dropdown">My Ribbon data <span class="caret"></span></a>
 					<ul class="dropdown-menu" role="menu" id="user_data_list">
-						<!-- Populated by add_user_links_to_navbar() in vis.js -->						
+						<!-- Populated by add_user_links_to_navbar() in vis.js -->
 					</ul>
 				</li>
 			</ul>
@@ -61,7 +57,50 @@
 	</div>
 <!--            End of Navigation Bar        -->
 
-<div id="ribbon-app-container">
+<ul class="nav nav-tabs" style="margin:10px;">
+	<li class="active"><a id="go_to_ribbon_mode" data-toggle="tab" href="#ribbon-app-container">Ribbon</a></li>
+	<li><a id="go_to_splitthreader_mode" data-toggle="tab" href="#splitthreader-app-container">SplitThreader</a></li>
+	<li><a id="go_to_about_mode" data-toggle="tab" href="#start_panel">About</a></li>
+</ul>
+
+<div class="tab-content">
+	<div id="start_panel" class="tab-pane">
+		<h4>Getting started</h4>
+		<p>Ribbon is especially useful for viewing complex alignments, like long-read sequencing around large structural variants,
+			alignments/variants that span more than one chromosome, or assembly/assembly alignments.</p>
+		<p>Start by loading a BAM file and navigating to a position. You can also load a VCF or BED file with variants or regions of interest.</p>
+
+		<!-- <p><strong>Examples:</strong></p>
+		<ul>
+			<li><a href="?perma=_ribbon/ilmn_deletion_a549" target="_blank">Illumina deletion in A549 cell line (600KB)</a></li>
+			<li><a href="?perma=_ribbon/grch38_vs_hg19" target="_blank">hg19 against GRCh38 (2 MB)</a></li>
+			<li><a href="?perma=_ribbon/pacb_skbr3_tra" target="_blank">PacBio SKBR3 TRA chr16 to chr19 (5MB)</a></li>
+			<li><a href="?perma=_ribbon/pacb_skbr3_gene_fusion" target="_blank">PacBio SKBR3 CYTH1-EIF3H gene fusion (11MB)</a></li>
+			<li><a href="?perma=_ribbon/grch38_vs_gorilla" target="_blank">Gorilla against GRCh38 (12MB)</a></li>
+		</ul> -->
+
+		<p><strong>Visualize your own alignment data:</strong></p>
+		<p>Ribbon can be used for long reads, short reads, paired-end reads, and assembly/genome alignments. Instructions for each data format are available by clicking on "instructions" in each tab on the right.</p>
+
+		<h3>SplitThreader</h3>
+		SplitThreader is now available within Ribbon!
+		Just click "SplitThreader" in the top navigation bar, and you can load your own coverage and structural variant files to visualize them.
+		There are also some examples to get you started.
+
+		<h3>Paper and code</h3>
+		<p><strong>Please cite the Ribbon paper in Bioinformatics:</strong></p>
+		<p>Ribbon: intuitive visualization for complex genomic variation: <a href="https://doi.org/10.1093/bioinformatics/btaa680" target="_blank">https://doi.org/10.1093/bioinformatics/btaa680</a></p>
+		<p>Also see the preprint on the BioRxiv for <a href="http://biorxiv.org/content/early/2016/10/20/082123" target="_blank">Ribbon.</a></p>
+		<p>And the preprint for <a href="https://www.biorxiv.org/content/10.1101/087981v1.full" target="_blank">SplitThreader</a>.</p>
+		
+
+		<p>The code is open-source at <a href="https://github.com/MariaNattestad/ribbon" target="_blank">https://github.com/MariaNattestad/Ribbon</a></p>
+		
+		<p><strong>Local installation:</strong></p>
+		<p>You can install Ribbon locally from Github by following the instructions here: <a href="https://github.com/MariaNattestad/ribbon" target="_blank">https://github.com/MariaNattestad/Ribbon</a></p>
+</div>
+
+<div id="ribbon-app-container" class="tab-pane active">
 	<div id="left_panel">
 		<div id="start_panel">
 			<div class="panel panel-default">
@@ -84,35 +123,6 @@
 						</ul>
 					</div>
 				</div>
-			<div class="panel panel-default">
-				<div class="panel-heading"><h3 class="panel-title">Info about Ribbon</h3></div>
-				<div class="panel-body">
-					<h3>Getting started</h3>
-					<p>Ribbon is especially useful for viewing complex alignments, like long-read sequencing around large structural variants,
-						alignments/variants that span more than one chromosome, or assembly/assembly alignments.</p>
-					<p>Start by loading a BAM file and navigating to a position. You can also load a VCF or BED file with variants or regions of interest.</p>
-
-					<p><strong>Visualize your own alignment data:</strong></p>
-					<p>Ribbon can be used for long reads, short reads, paired-end reads, and assembly/genome alignments. Instructions for each data format are available by clicking on "instructions" in each tab on the right.</p>
-
-					<h3>SplitThreader</h3>
-					SplitThreader is now available within Ribbon!
-					Just click "SplitThreader" in the top navigation bar, and you can load your own coverage and structural variant files to visualize them.
-					There are also some examples to get you started.
-
-					<h3>Paper and code</h3>
-					<p><strong>Please cite the Ribbon paper in Bioinformatics:</strong></p>
-					<p>Ribbon: intuitive visualization for complex genomic variation: <a href="https://doi.org/10.1093/bioinformatics/btaa680" target="_blank">https://doi.org/10.1093/bioinformatics/btaa680</a></p>
-					<p>Also see the preprint on the BioRxiv for <a href="http://biorxiv.org/content/early/2016/10/20/082123" target="_blank">Ribbon.</a></p>
-					<p>And the preprint for <a href="https://www.biorxiv.org/content/10.1101/087981v1.full" target="_blank">SplitThreader</a>.</p>
-					
-					<p>The code is open-source at <a href="https://github.com/MariaNattestad/ribbon" target="_blank">https://github.com/MariaNattestad/Ribbon</a></p>
-					
-					<p><strong>Local installation:</strong></p>
-					<p>You can install Ribbon locally from Github by following the instructions here: <a href="https://github.com/MariaNattestad/ribbon" target="_blank">https://github.com/MariaNattestad/Ribbon</a></p>
-
-				</div>
-			</div>
 		</div>
 
 		<div id="svg2_panel"></div>
@@ -524,7 +534,7 @@
 	</div>
 </div>
 
-<div id="splitthreader-app-container" style="display: none">
+<div id="splitthreader-app-container" class="tab-pane">
 	<div id="main_body_container">
 		<ul class="nav nav-tabs">
 			<li id="nav_tab_splitthreader_setup" class="nav_tab_splitthreader active in"><a data-toggle="tab" href="#setup_tab">Setup</a></li>
@@ -1009,6 +1019,8 @@ chrom1,start1,stop1,chrom2,start2,stop2,variant_name,score,strand1,strand2,varia
 		</div> <!-- end tab content class -->
 	</div>
 </div> <!-- end splitthreader app container -->
+
+</div>
 
 <!-- Keeping old bootstrap to avoid major html updates for now -->
 <!-- This old bootstrap can't really be imported by our own JS, but 

--- a/index.html
+++ b/index.html
@@ -27,41 +27,35 @@
 	<link href="css/splitthreader.css" rel="stylesheet">
 </head>
 
-<!--    NAVIGATION BAR-->
-
 <body role="document">
+	<!-- Navigation bar -->
 	<div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-		<div class="container">
-			
-			<div class="navbar-header">
-				<button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-					<span class="sr-only">Toggle navigation</span>
-					<span class="icon-bar"></span>
-					<span class="icon-bar"></span>
-					<span class="icon-bar"></span>
-				</button>
-			</div>
-			<!-- <div class="navbar-collapse collapse"> -->
-			<ul class="nav navbar-nav" id="navbar">
-				<li><a href="/">Ribbon</a></li>
-				<li class="dropdown" id="user_data_navbar_item" style="visibility: hidden">
-					<a href="" class="dropdown-toggle" data-toggle="dropdown">My Ribbon data <span class="caret"></span></a>
-					<ul class="dropdown-menu" role="menu" id="user_data_list">
-						<!-- Populated by add_user_links_to_navbar() in vis.js -->
-					</ul>
-				</li>
-			</ul>
-			<!-- </div> -->
-			<!--/.nav-collapse -->
-		</div>
+		<ul class="nav navbar-nav" id="navbar">
+			<li><a href="/">Ribbon</a></li>
+			<li class="dropdown" id="user_data_navbar_item" style="visibility: hidden">
+				<a href="" class="dropdown-toggle" data-toggle="dropdown">My Ribbon data <span class="caret"></span></a>
+				<ul class="dropdown-menu" role="menu" id="user_data_list">
+					<!-- Populated by add_user_links_to_navbar() in vis.js -->
+				</ul>
+			</li>
+		</ul>
+		<ul class="nav navbar-nav navbar-right" style="margin-right: 10px;">
+			<li class="navbar-text small">
+				<small>
+					This is a beta of Ribbon 2.0
+					(<a style="padding:0; display:inline; color:#fff" href="https://github.com/MariaNattestad/Ribbon/blob/v2/docs/release_notes_v2.md" target="_blank">learn more</a>).
+					You can go <a style="padding:0; display:inline; color:#fff" href="https://v1.genomeribbon.com" target="_blank">back to v1</a>.
+				</small>
+			</li>
+		</ul>
 	</div>
-<!--            End of Navigation Bar        -->
 
-<ul class="nav nav-tabs" style="margin:10px;">
-	<li class="active"><a id="go_to_ribbon_mode" data-toggle="tab" href="#ribbon-app-container">Ribbon</a></li>
-	<li><a id="go_to_splitthreader_mode" data-toggle="tab" href="#splitthreader-app-container">SplitThreader</a></li>
-	<li><a id="go_to_about_mode" data-toggle="tab" href="#start_panel">About</a></li>
-</ul>
+	<!-- Main tabs -->
+	<ul class="nav nav-tabs" style="margin:10px;">
+		<li class="active"><a id="go_to_ribbon_mode" data-toggle="tab" href="#ribbon-app-container">Ribbon</a></li>
+		<li><a id="go_to_splitthreader_mode" data-toggle="tab" href="#splitthreader-app-container">SplitThreader</a></li>
+		<li><a id="go_to_about_mode" data-toggle="tab" href="#start_panel">About</a></li>
+	</ul>
 
 <div class="tab-content">
 	<div id="start_panel" class="tab-pane">

--- a/js/index.js
+++ b/js/index.js
@@ -93,11 +93,11 @@ function check_url_for_mode() {
   const hash = window.location.hash;
 
   if (hash === "#splitthreader") {
-    go_to_splitthreader_mode();
+    document.getElementById("go_to_splitthreader_mode").click()
   } else if (hash === "#ribbon") {
-    go_to_ribbon_mode();
-  } else if (hash === "") {
-    // Do nothing
+    document.getElementById("go_to_ribbon_mode").click()
+  } else if (hash === "#about") {
+    document.getElementById("go_to_about_mode").click()
   } else {
     console.error("unknown hash in URL:", hash);
   }

--- a/js/index_ribbon.js
+++ b/js/index_ribbon.js
@@ -381,8 +381,6 @@ function resize_ribbon_views() {
     .style("height", _layout.total_height + "px")
     .style("visibility", "visible");
 
-  d3.select("#info_panel").style("width", _layout.svg2_width + "px");
-  d3.select("#start_panel").style("width", _layout.svg2_width + "px");
   d3.select("#advanced_settings_panel").style(
     "width",
     _layout.svg2_width + "px"
@@ -4364,10 +4362,8 @@ function organize_references_for_read() {
 function refresh_visibility() {
   if (_Whole_refs.length > 0 || _Chunk_alignments.length > 0) {
     d3.select("#svg2_panel").style("visibility", "visible");
-    d3.select("#start_panel").style("display", "none");
   } else {
     d3.select("#svg2_panel").style("visibility", "hidden");
-    d3.select("#start_panel").style("display", "block");
   }
 
   if (
@@ -5598,18 +5594,6 @@ function draw_ribbons() {
 // == Examples
 // ===========================================================================
 
-function show_getting_started_panel() {
-  if (d3.select("#start_panel").style("display") == "none") {
-    d3.select("#start_panel").style("display", "block");
-  } else {
-    d3.select("#start_panel").style("display", "none");
-  }
-}
-d3.select("#click_getting_started_link").on(
-  "click",
-  show_getting_started_panel
-);
-
 // Cookie Management (documentation: https://www.w3schools.com/js/js_cookies.asp)
 // ¯\_(ツ)_/¯
 function get_cookie() {
@@ -6707,9 +6691,6 @@ function resizeWindow() {
 // ===========================================================================
 
 export function go_to_ribbon_mode() {
-  d3.select("#ribbon-app-container").style("display", "block");
-  d3.select("#splitthreader-app-container").style("display", "none");
-
   // Grab any shared data that SplitThreader may have deposited.
   if (window.global_variants) {
     _Bedpe = window.global_variants;
@@ -6722,6 +6703,9 @@ d3.select("#go_to_ribbon_mode").on("click", function() {
   go_to_ribbon_mode();
   window.location.hash = '#ribbon';
 });
+d3.select("#go_to_about_mode").on("click", function() {
+  window.location.hash = '#about';
+});
 
 // ===========================================================================
 // == Main
@@ -6729,7 +6713,6 @@ d3.select("#go_to_ribbon_mode").on("click", function() {
 
 run_ribbon();
 open_any_url_files();
-
 
 // window.addEventListener("beforeunload", function (event) {
 //   event.preventDefault();

--- a/js/index_splitthreader.js
+++ b/js/index_splitthreader.js
@@ -2220,7 +2220,7 @@ function draw_connections() {
     return;
   }
   if (
-    _Filtered_variant_data.length > _splitthreader_static.max_variants_to_show
+    _Filtered_variant_data?.length > _splitthreader_static.max_variants_to_show
   ) {
     user_message_splitthreader(
       "Warning",
@@ -4354,8 +4354,6 @@ export async function load_bedpe_from_url(url) {
 }
 
 export function go_to_splitthreader_mode() {
-  d3.select("#ribbon-app-container").style("display", "none");
-  d3.select("#splitthreader-app-container").style("display", "block");
   if (window.global_variants) {
     _Filtered_variant_data = window.global_variants;
     update_variants();


### PR DESCRIPTION
Move navbar items into tabs, with support for `#ribbon`, `#splitthreader` in URLs

![Screenshot 2024-08-27 at 8 36 37 PM](https://github.com/user-attachments/assets/7d9fd71b-7592-4a61-860f-f86e99a817d1)
