### PR TITLE
Download & mount BAIs in one shot instead of 1MB at a time

### DIFF
--- a/js/index_ribbon.js
+++ b/js/index_ribbon.js
@@ -5658,7 +5658,7 @@ export async function read_bam_urls(urls, in_background = false) {
       return;
     }
 
-    let new_bam = new BamFile([url, url + ".bai"]);
+    let new_bam = new BamFile([url]);
     await new_bam.mount();
     await new_bam.parseHeader();
     _Bams.push(new_bam);


### PR DESCRIPTION
On my computer, goes from 1.6min to 37s for http://localhost:3000/?session=https://42basepairs.com/download/s3/giab-data/ribbon-json/ribbon-hg008-cov-gridss.json&locus=chr1:23272628#ribbon