### PR TITLE
Set default alignment color to orientation

### DIFF
--- a/js/index_ribbon.js
+++ b/js/index_ribbon.js
@@ -215,7 +215,7 @@ _ribbon_settings.show_only_known_references = true;
 _ribbon_settings.keep_duplicate_reads = false;
 _ribbon_settings.feature_to_sort_reads = "original";
 _ribbon_settings.orient_reads_by = "primary";
-_ribbon_settings.color_alignments_by = "strand";
+_ribbon_settings.color_alignments_by = "orientation";
 
 _ribbon_settings.current_input_type = "";
 _ribbon_settings.ref_match_chunk_ref_intervals = true;


### PR DESCRIPTION
Changing the default back because I do find it more useful to show consistent orientation for most reads when possible, and I kept setting this back to "orientation" when using Ribbon or taking demo pictures.


Was the default just for the past month:
<img width="1784" alt="Screenshot 2024-09-13 at 8 05 23 PM" src="https://github.com/user-attachments/assets/824b57b2-07de-4581-8751-47ff64c8fd08">

Previous default brought back by this PR:
<img width="1784" alt="Screenshot 2024-09-13 at 8 05 12 PM" src="https://github.com/user-attachments/assets/49675bad-1119-42d2-99b2-07f42f70efe1">
