### PR TITLE
fix: paired-end BAM coloring bug + signed BAI URL support

### DIFF
--- a/js/file_parsing.js
+++ b/js/file_parsing.js
@@ -66,7 +66,10 @@ export class BamFile extends GenomicFile {
 
     // Download BAI in one go so it's faster than downloading it 1 MB at a time when lazy mount a URL with Aioli
     const bam_url = this.files[0];
-    const bai_url = bam_url + ".bai";
+    // this.files[1], if present, is an explicit BAI URL (needed for signed URLs, where
+    // naively appending ".bai" to the BAM URL breaks its query-string signature and doesn't
+    // point at a validly-signed BAI object anyway - the BAI needs its own independent signature).
+    const bai_url = this.files[1] || (bam_url + ".bai");
     let blob;
     try {
       blob = await fetch(bai_url).then(d => d.blob());

--- a/js/index_ribbon.js
+++ b/js/index_ribbon.js
@@ -2288,6 +2288,14 @@ function parse_paired_end(record) {
       pair_link_positions.to["false"] - pair_link_positions.from["false"]
     )
   );
+  // "color by BAM file" (see color_alignments_by === "bam" below) reads chunks[i].raw.bam - but
+  // `record` here is {first, second}, and each of those is the object parse_bam_record() built
+  // ({alignments, raw, raw_type, readname, flag}) - the .bam index set in my_fetch() lives on
+  // the ORIGINAL record, one level deeper at .raw.bam, not directly on record.first/.second. So
+  // that field was always undefined for every paired-end chunk, making every chunk resolve to
+  // the same color regardless of which BAM it came from. Both mates of one pair always come from
+  // the same BAM file, so either one's .raw.bam is the right answer.
+  record.bam = record.first ? record.first.raw.bam : (record.second ? record.second.raw.bam : undefined);
   return {
     raw_type: "paired-end",
     readname: readname,
@@ -5685,7 +5693,11 @@ function set_variant_info_text() {
 
 export async function read_bam_urls(urls, in_background = false) {
   _Bams = [];
-  for (let url of urls) {
+  for (let url_pair of urls) {
+    // Optional "bam_url|bai_url" pairing, for signed URLs where the BAI can't be derived by
+    // just appending ".bai" to the BAM URL (that breaks the query-string signature, and the
+    // BAI needs its own independently-signed URL anyway).
+    let [url, bai_url] = url_pair.split("|");
     if (url.startsWith("s3://")) {
       url = url.replace("s3://", "https://42basepairs.com/download/s3/");
     } else if (url.startsWith("gs://")) {
@@ -5695,7 +5707,7 @@ export async function read_bam_urls(urls, in_background = false) {
       return;
     }
 
-    let new_bam = new BamFile([url]);
+    let new_bam = new BamFile(bai_url ? [url, bai_url] : [url]);
     await new_bam.mount();
     await new_bam.parseHeader();
     _Bams.push(new_bam);


### PR DESCRIPTION
Color reads by: Which BAM file each read came from" always rendered every read the same color when viewing paired-end data. parse_paired_end() merges a read's two mates into one chunk and set raw.bam from the merged {first, second} wrapper object, which never had a .bam field itself - the index set in my_fetch() lives one level deeper, on record.first.raw.bam. Fixed by reading it from there.

Also added an optional "bam_url|bai_url" pairing in read_bam_urls(), for BAMs served via time-limited signed URLs (e.g. GCS/S3 presigned GET URLs). BamFile.mount() derives the BAI URL by appending ".bai" to the BAM URL, which breaks a signed URL's query-string signature and doesn't point at a validly-signed BAI object anyway - the BAI needs its own independent signature. Passing both explicitly as "bam_url|bai_url" (falling back to the existing ".bai"-suffix behavior when no "|" is present) works around this without changing the default single-URL case.